### PR TITLE
Remove grunt 0.4 from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
   "scripts": {
     "test": "node test/test.js"
   },
-  "peerDependencies": {
-    "grunt": "~0.4"
-  },
   "devDependencies": {
     "grunt": "~0.4",
     "grunt-contrib-jshint": "~0.1"


### PR DESCRIPTION
As grunt 1.0 is coming, I propose to remove grunt 0.4 from peer dependencies
